### PR TITLE
Expose StartHeight for when the genesis height does not start at 1

### DIFF
--- a/cli/genesis.go
+++ b/cli/genesis.go
@@ -5,15 +5,16 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/staking/api"
-	"github.com/tendermint/tendermint/crypto"
 	"oasisTracker/common/log"
 	"oasisTracker/dao"
 	"oasisTracker/dmodels"
 	"oasisTracker/dmodels/oasis"
 	"oasisTracker/smodels"
 	"os"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/staking/api"
+	"github.com/tendermint/tendermint/crypto"
 )
 
 const SetupGenesisJson = "setup-genesis"
@@ -37,8 +38,6 @@ func NewCli(d dao.DAO) ICli {
 		DAO: pDAO,
 	}
 }
-
-const genesisHeight = 0
 
 func (cli *Cli) Setup(args []string) error {
 	if len(args) == 0 {
@@ -84,7 +83,7 @@ func (cli *Cli) SetupGenesisJson(args []string) error {
 		balances[i] = dmodels.AccountBalance{
 			Account:               accountAddress.String(),
 			Time:                  gen.GenesisTime,
-			Height:                genesisHeight,
+			Height:                int64(gen.GenesisHeight),
 			Nonce:                 balance.General.Nonce,
 			GeneralBalance:        balance.General.Balance.ToBigInt().Uint64(),
 			EscrowBalanceActive:   balance.Escrow.Active.Balance.ToBigInt().Uint64(),
@@ -110,7 +109,7 @@ func (cli *Cli) SetupGenesisJson(args []string) error {
 			txHash := sha256.Sum256([]byte(fmt.Sprint(gen.ChainID, "delegation", receiverAddress, senderAddress, share.Shares.String())))
 
 			txs = append(txs, dmodels.Transaction{
-				BlockLevel:          genesisHeight,
+				BlockLevel:          gen.GenesisHeight,
 				BlockHash:           hex.EncodeToString(genesisBlockHash[:]),
 				Hash:                hex.EncodeToString(txHash[:]),
 				Time:                gen.GenesisTime,
@@ -141,7 +140,7 @@ func (cli *Cli) SetupGenesisJson(args []string) error {
 				txHash := sha256.Sum256([]byte(fmt.Sprint(gen.ChainID, "reclaim", debonder, staker, shareArr[i].Shares.String())))
 
 				txs = append(txs, dmodels.Transaction{
-					BlockLevel:          genesisHeight,
+					BlockLevel:          gen.GenesisHeight,
 					BlockHash:           hex.EncodeToString(genesisBlockHash[:]),
 					Hash:                hex.EncodeToString(txHash[:]),
 					Time:                gen.GenesisTime,
@@ -186,7 +185,7 @@ func (cli *Cli) SetupGenesisJson(args []string) error {
 		}
 
 		nodes[i] = dmodels.NodeRegistryTransaction{
-			BlockLevel:       genesisHeight,
+			BlockLevel:       gen.GenesisHeight,
 			Hash:             gen.Registry.Nodes[i].Hash().String(),
 			Time:             gen.GenesisTime,
 			ID:               node.ID.String(),
@@ -222,7 +221,7 @@ func (cli *Cli) SetupGenesisJson(args []string) error {
 		}
 
 		entities[i] = dmodels.EntityRegistryTransaction{
-			BlockLevel:             genesisHeight,
+			BlockLevel:             gen.GenesisHeight,
 			Hash:                   gen.Registry.Entities[i].Hash().String(),
 			Time:                   gen.GenesisTime,
 			ID:                     entity.ID.String(),

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -21,9 +21,10 @@ type (
 		CORSAllowedOrigins []string
 	}
 	Scanner struct {
-		NodeRPS    uint64
-		BatchSize  uint64
-		NodeConfig string
+		StartHeight uint64
+		NodeRPS     uint64
+		BatchSize   uint64
+		NodeConfig  string
 	}
 	Cron struct {
 		ParseValidatorsRegisterInterval uint64

--- a/config.example.json
+++ b/config.example.json
@@ -7,23 +7,25 @@
     ]
   },
   "Clickhouse": {
-    "Protocol": "http",
+    "Protocol": "tcp",
     "Host": "localhost",
-    "Port": 8123,
+    "Port": 9000,
     "User": "default",
-    "Password": ""
+    "Password": "",
+    "Database": "default"
   },
-  "Mysql": {
-    "Host": "127.0.0.1",
-    "Port": 3306,
-    "User": "root",
-    "Password": "123",
+  "Postgres": {
+    "Host": "localhost",
+    "Port": 5432,
+    "User": "oasis",
+    "Password": "oasis",
     "Database": "oasis",
-    "DebugMode": true
+    "Schema": "oasis"
   },
   "Scanner": {
     "Database": "oasis",
     "NodeRPS": 200,
-    "NodeConfig": "127.0.0.1:9109"
+    "NodeConfig": "127.0.0.1:9109",
+    "StartHeight": 1
   }
 }

--- a/dao/postgres/postgres.go
+++ b/dao/postgres/postgres.go
@@ -3,10 +3,11 @@ package postgres
 import (
 	"database/sql"
 	"fmt"
-	"github.com/golang-migrate/migrate/v4/database/postgres"
-	"github.com/jinzhu/gorm"
 	"oasisTracker/common/dao"
 	"oasisTracker/conf"
+
+	"github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/jinzhu/gorm"
 )
 
 const migrationsDir = "./dao/postgres/migrations"

--- a/services/scanners/watcher.go
+++ b/services/scanners/watcher.go
@@ -3,11 +3,12 @@ package scanners
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"oasisTracker/common/log"
 	"oasisTracker/conf"
 	"oasisTracker/dao"
 	"oasisTracker/dmodels"
+
+	"go.uber.org/zap"
 )
 
 type Watcher struct {
@@ -94,9 +95,11 @@ func (m *Watcher) addReSyncTask(currentHeight int64) error {
 		return fmt.Errorf("GetLastTask error: %s", err)
 	}
 
-	startHeight := task.EndHeight + 1
+	var startHeight uint64
 	if !isFound {
-		startHeight = 0
+		startHeight = m.cfg.Scanner.StartHeight
+	} else {
+		startHeight = task.EndHeight + 1
 	}
 
 	//Blocks sync

--- a/smodels/genesis.go
+++ b/smodels/genesis.go
@@ -1,18 +1,20 @@
 package smodels
 
 import (
+	"time"
+
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	"github.com/oasisprotocol/oasis-core/go/staking/api"
-	"time"
 )
 
 type GenesisDocument struct {
-	GenesisTime time.Time    `json:"genesis_time"`
-	EpochTime   GenesisEpoch `json:"epochtime"`
-	ChainID     string       `json:"chain_id"`
-	Registry    Registry     `json:"registry"`
-	Staking     Staking      `json:"staking"`
+	GenesisTime   time.Time    `json:"genesis_time"`
+	GenesisHeight uint64       `json:"height"`
+	EpochTime     GenesisEpoch `json:"epochtime"`
+	ChainID       string       `json:"chain_id"`
+	Registry      Registry     `json:"registry"`
+	Staking       Staking      `json:"staking"`
 }
 
 type Registry struct {


### PR DESCRIPTION
The genesis files do not start from block 1 and therefore the scanner gets stuck with errors such as below and never completes it's firsst tasks : 

```
2021-02-21T04:20:06.005Z        error   Scanner Result  {"error": "block 1: api.Block.Get: rpc error: code = Unknown desc = tendermint: block query failed: height 1 is not available, lowest height is 2284801", "task": "base"}
```

I've added `StartHeight` to the config struct that is used if there is no previous task in the database.

I've also updated the config example accordingly, with a few other fixes : 

- Added `StartHeight`
- Updated from MySQL to PostgreSQL
- Changed the Clickhouse ports & proto to tcp/9000 : For me, 8123 + http was behaving strangely, and the official documentation of the library recommended 9000 with TCP
- Changed the config to show how to use the unix socket file for the oasis-node